### PR TITLE
chore: placeholder DX tweak

### DIFF
--- a/core/mod.ts
+++ b/core/mod.ts
@@ -3,3 +3,4 @@ export * from "./Ls.ts";
 export * from "./Rc.ts";
 export * from "./Rec.ts";
 export * from "./Try.ts";
+export * from "./unsafe/mod.ts";

--- a/core/unsafe/Each.ts
+++ b/core/unsafe/Each.ts
@@ -1,2 +1,15 @@
-// TODO
-export {};
+import { $, EffectLike, T } from "../../Effect.ts";
+import { ls } from "../Ls.ts";
+import { derive } from "./Derive.ts";
+
+export function each<
+  Elements extends $<unknown[]>,
+  Into extends EffectLike,
+>(
+  elements: Elements,
+  cb: (element: T<Elements>[number]) => Into,
+) {
+  return derive(elements, (resolved) => {
+    return ls(...resolved.map(cb));
+  });
+}

--- a/core/unsafe/If.ts
+++ b/core/unsafe/If.ts
@@ -1,15 +1,21 @@
-// TODO: utilize `Derive` under the hood
-import { $, E, Effect, T, V } from "../../Effect.ts";
+import { $, EffectLike } from "../../Effect.ts";
+import { derive } from "./Derive.ts";
 
-export { if_ as if };
-function if_<Condition extends $<boolean>, Then, Else = void>(
+function if_<
+  Condition extends $<boolean>,
+  Then extends EffectLike,
+  Else extends EffectLike,
+>(
   condition: Condition,
   then: Then,
   else_: Else = undefined!,
-): Effect<
-  T<Then | Else>,
-  E<Condition | Then | Else>,
-  V<Condition | Then | Else>
-> {
-  return new Effect("If", () => () => {}, [condition, then, else_]);
+) {
+  return derive(condition, (condition) => {
+    return condition ? then : else_;
+  });
 }
+Object.defineProperty(if_, "name", {
+  value: "if",
+  writable: false,
+});
+export { if_ as if };

--- a/core/unsafe/mod.ts
+++ b/core/unsafe/mod.ts
@@ -1,3 +1,2 @@
-export * from "./Derive.ts";
 export * from "./Each.ts";
 export * from "./If.ts";

--- a/examples/derived.ts
+++ b/examples/derived.ts
@@ -1,4 +1,4 @@
-import { derive } from "../core/unsafe/mod.ts";
+import { derive } from "../core/unsafe/Derive.ts";
 import * as Z from "../mod.ts";
 
 const coinToss = Z.call(0, () => {

--- a/examples/placeholders.ts
+++ b/examples/placeholders.ts
@@ -9,7 +9,7 @@ const second = Z._<number>()(second_);
 const third_ = Symbol();
 const third = Z._<boolean>()(third_);
 
-const run = Z.runtime(first("HELLO"));
+const run = Z.runtime(first.a("HELLO"));
 
 const root = Z.call(Z.ls(first, second, third), ([first, second, third]) => {
   console.log({ first, second, third });
@@ -18,8 +18,8 @@ const root = Z.call(Z.ls(first, second, third), ([first, second, third]) => {
 
 const result = await run(root, (_) =>
   _(
-    second(100),
-    third(true),
+    second.a(100),
+    third.a(true),
   ));
 
 console.log(result);


### PR DESCRIPTION
Previously, placeholders could be applied by simply calling one.

```ts
const result = await run(root, (_) =>
  _(
    placeholder(100),
  ));
```

However, this created issues with inference on arguments that are typed as maybe-effect functions.

```ts
const useAdd = Z.call.fac((add: (a: number, b: number) => number) => {
  return add(1, 2);
});

useAdd((a, b) => {
  return a + b;
})
```

Here, `a` and `b` are not inferred as being of type number. The possibility for a placeholder breaks the inference.

For now, we'll address this like so:

```diff
const result = await run(root, (_) =>
  _(
-   placeholder(100),
+   placeholder.a(100),
  ));
```