### PR TITLE
chore: id cleanup

### DIFF
--- a/Effect.ts
+++ b/Effect.ts
@@ -6,9 +6,6 @@ declare const T_: unique symbol;
 declare const E_: unique symbol;
 declare const V_: unique symbol;
 
-declare const effectId: unique symbol;
-export type EffectId = U.sig.Signature & { [effectId]?: true };
-
 export class Effect<
   T = any,
   E extends Error = Error,
@@ -23,11 +20,9 @@ export class Effect<
   constructor(
     readonly kind: string,
     readonly run: EffectInitRun,
-    readonly args?: unknown[],
+    readonly children?: unknown[],
   ) {
-    this.id = `${this.kind}(${
-      this.args?.map(U.sig.of).join(",") || ""
-    })` as EffectId;
+    this.id = `${this.kind}(${this.children?.map(U.id.of).join(",") || ""})`;
   }
 }
 
@@ -37,7 +32,7 @@ export type EffectInitRun = (process: Process) => () => unknown;
 export abstract class Name<Root extends EffectLike = EffectLike> {
   abstract root: Root;
 
-  get id(): EffectId {
+  get id(): string {
     return this.root.id;
   }
 }

--- a/Process.ts
+++ b/Process.ts
@@ -1,7 +1,7 @@
-import { Effect, EffectId, EffectLike, isEffectLike, Name } from "./Effect.ts";
+import { EffectLike, isEffectLike, Name } from "./Effect.ts";
 import { isPlaceholder } from "./Placeholder.ts";
 
-export class Process extends Map<EffectId, () => unknown> {
+export class Process extends Map<string, () => unknown> {
   #context = new WeakMap<new() => unknown, unknown>();
 
   constructor(private applies: Record<PropertyKey, unknown>) {
@@ -20,7 +20,7 @@ export class Process extends Map<EffectId, () => unknown> {
         if (!run) {
           run = currentSource.run(this);
           this.set(currentSource.id, run);
-          currentSource.args?.forEach((arg) => {
+          currentSource.children?.forEach((arg) => {
             if (isEffectLike(arg)) {
               stack.push(arg);
             }

--- a/core/call.ts
+++ b/core/call.ts
@@ -3,11 +3,10 @@ import { thrownAsUntypedError } from "../Error.ts";
 import * as U from "../util/mod.ts";
 import { ls, Ls$ } from "./ls.ts";
 
-export function call<D, R>(dep: D, logic: CallLogic<D, R>): Effect<
-  Exclude<Awaited<R>, Error>,
-  E<D> | Extract<Awaited<R>, Error>,
-  V<D>
-> {
+export function call<D, R>(
+  dep: D,
+  logic: CallLogic<D, R>,
+): Effect<Exclude<Awaited<R>, Error>, E<D> | Extract<Awaited<R>, Error>, V<D>> {
   return new Effect("Call", (process) => {
     return U.memo(() => {
       return U.thenOk(process.resolve(dep), thrownAsUntypedError(logic));

--- a/core/rc.ts
+++ b/core/rc.ts
@@ -7,7 +7,7 @@ export function rc<Target, Keys extends unknown[]>(
 ): Effect<() => number, E<Target | Keys[number]>, V<Target | Keys[number]>> {
   return new Effect("Rc", (process) => {
     const rcContext = process.context(RcContext);
-    const sig = U.sig.of(target);
+    const sig = U.id.of(target);
     rcContext.increment(sig);
     return () => {
       return () => {

--- a/examples/client.ts
+++ b/examples/client.ts
@@ -31,14 +31,13 @@ class InnerClient {
 }
 
 function client<Url extends Z.$<string>>(url: Url) {
-  return Z.call(url, clientImpl);
-}
-function clientImpl(url: string) {
-  console.log("ENTER CLIENT");
-  if (false as boolean) {
-    return new ClientConnectError();
-  }
-  return new InnerClient(url);
+  return Z.call(url, function clientImpl(url) {
+    console.log("ENTER CLIENT");
+    if (false as boolean) {
+      return new ClientConnectError();
+    }
+    return new InnerClient(url);
+  });
 }
 
 function call<
@@ -66,10 +65,9 @@ function call<
   );
 }
 
-const client_ = client("wss://rpc.polkadot.io");
-const callA = call(client_, "someMethodA", [1, 2, 3]);
-const callB = call(client_, "someMethodB", [4, 5, 6]);
-const callC = call(client_, "someMethodC", [7, 8, 9]);
+const callA = call(client("wss://rpc.polkadot.io"), "someMethodA", [1, 2, 3]);
+const callB = call(client("wss://rpc.polkadot.io"), "someMethodB", [4, 5, 6]);
+const callC = call(client("wss://rpc.polkadot.io"), "someMethodC", [7, 8, 9]);
 
 const result = await Z.runtime()(Z.ls(callA, callB, callC));
 

--- a/examples/deduped.ts
+++ b/examples/deduped.ts
@@ -1,0 +1,12 @@
+import * as Z from "../mod.ts";
+
+let i = 0;
+
+function f() {
+  return Z.call(0, () => {
+    console.log(i++);
+    return "HELLO!";
+  });
+}
+
+await Z.runtime()(Z.ls(f(), f()));

--- a/util/id.ts
+++ b/util/id.ts
@@ -1,10 +1,7 @@
 import { isEffectLike } from "../Effect.ts";
 import * as U from "../util/mod.ts";
 
-declare const signature_: unique symbol;
-export type Signature = string & { [signature_]?: true };
-
-class SignatureFactory<T> {
+class IdFactory<T> {
   #i = 0;
 
   constructor(
@@ -23,19 +20,22 @@ class SignatureFactory<T> {
 }
 
 export const strongContainer = new Map();
-export const strong = new SignatureFactory("strong", strongContainer);
-export const weak = new SignatureFactory("weak", new WeakMap());
+export const strong = new IdFactory("strong", strongContainer);
+export const weak = new IdFactory("weak", new WeakMap());
 
-export function of(target: unknown): Signature {
+export function of(target: unknown): string {
   switch (typeof target) {
     case "function": {
-      return weak.of(target as (...args: any[]) => any);
+      if (!target.name) {
+        return weak.of(target as (...args: any[]) => any);
+      }
+      return `fn(${target.name})`;
     }
     case "object": {
       if (isEffectLike(target)) {
         return target.id;
       } else if (target === null) {
-        return "null" as Signature;
+        return "null";
       }
       return weak.of(target);
     }

--- a/util/mod.ts
+++ b/util/mod.ts
@@ -1,5 +1,5 @@
 export * from "./common.ts";
 export * from "./error.ts";
+export * as id from "./id.ts";
 export * from "./memo.ts";
-export * as sig from "./sig.ts";
 export * from "./xsync.ts";


### PR DESCRIPTION
Consider the following example:

```ts
import * as Z from "../mod.ts";

let i = 0;

function f() {
  return Z.call(0, () => {
    console.log(i++);
    return "HELLO!";
  });
}

await Z.runtime()(Z.ls(f(), f()));
```

This will print out `0` then `1`. This is because `f` produces effects with **different** function references.

We can solve this in one of two ways:

1. Extract the logic into an outer fn.
2. (more convenient) Specify a function name.

```diff
- return Z.call(0, () => {
+ return Z.call(0, function fImpl() {
```