### PR TITLE
feat: reflecting on untyped error

### DIFF
--- a/core/call.ts
+++ b/core/call.ts
@@ -7,11 +7,12 @@ export function call<D, R>(
   dep: D,
   logic: CallLogic<D, R>,
 ): Effect<Exclude<Awaited<R>, Error>, E<D> | Extract<Awaited<R>, Error>, V<D>> {
-  return new Effect("Call", (process) => {
-    return U.memo(() => {
-      return U.thenOk(process.resolve(dep), thrownAsUntypedError(logic));
+  const e = new Effect("Call", (process) => {
+    return U.memo((): unknown => {
+      return U.thenOk(process.resolve(dep), thrownAsUntypedError(e, logic));
     });
   }, [dep, logic]);
+  return e as any;
 }
 export namespace call {
   export function fac<A extends unknown[], R>(fn: (...args: A) => R) {

--- a/core/derive.ts
+++ b/core/derive.ts
@@ -12,14 +12,15 @@ export function derive<Target, UseResult extends EffectLike>(
   | E<Extract<Awaited<UseResult>, EffectLike>>,
   V<Target> | V<Awaited<UseResult>>
 > {
-  return new Effect("Derive", (process) => {
-    return () => {
+  const e = new Effect("Derive", (process) => {
+    return (): unknown => {
       return U.thenOk(
-        U.then(process.resolve(from), thrownAsUntypedError(into)),
+        U.then(process.resolve(from), thrownAsUntypedError(e, into)),
         (e) => process.init(e)(),
       );
     };
   }, [from, into]);
+  return e as any;
 }
 
 export type DeriveResult = Error | EffectLike | Promise<Error | EffectLike>;

--- a/examples/untyped_error.ts
+++ b/examples/untyped_error.ts
@@ -1,0 +1,14 @@
+import * as Z from "../mod.ts";
+
+const untypedError = Z.call(0, () => {
+  if (true as boolean) {
+    throw new Error();
+  }
+  return "HELLO";
+});
+
+const result = Z.runtime()(untypedError);
+
+if (result instanceof Z.UntypedError) {
+  console.log(result.source);
+}


### PR DESCRIPTION
Helps with debugging.

```ts
import * as Z from "../mod.ts";

const untypedError = Z.call(0, () => {
  if (true as boolean) {
    throw new Error();
  }
  return "HELLO";
});

const result = Z.runtime()(untypedError);

if (result instanceof Z.UntypedError) {
  console.log(result.source);
}
```