### PR TITLE
chore: clean up rc and deduped example

### DIFF
--- a/effects/rc.ts
+++ b/effects/rc.ts
@@ -2,9 +2,12 @@ import { E, Effect, T, V } from "../Effect.ts";
 import * as U from "../util/mod.ts";
 import { LsT } from "./ls.ts";
 
-export type RcT<Keys extends [unknown, ...unknown[]]> = [LsT<Keys>, Counter];
+export type RcT<Keys extends [target: unknown, ...keys: unknown[]]> = [
+  LsT<Keys>,
+  Counter,
+];
 
-export function rc<Keys extends [unknown, ...unknown[]]>(
+export function rc<Keys extends [target: unknown, ...keys: unknown[]]>(
   ...keys: Keys
 ): Effect<RcT<Keys>, E<Keys[number]>, V<Keys[number]>> {
   return new Effect("Rc", (process) => {

--- a/effects/rc.ts
+++ b/effects/rc.ts
@@ -1,35 +1,27 @@
-import { E, Effect, V } from "../Effect.ts";
+import { E, Effect, T, V } from "../Effect.ts";
 import * as U from "../util/mod.ts";
+import { LsT } from "./ls.ts";
 
-export function rc<Target, Keys extends unknown[]>(
-  target: Target,
+export type RcT<Keys extends [unknown, ...unknown[]]> = [LsT<Keys>, Counter];
+
+export function rc<Keys extends [unknown, ...unknown[]]>(
   ...keys: Keys
-): Effect<() => number, E<Target | Keys[number]>, V<Target | Keys[number]>> {
+): Effect<RcT<Keys>, E<Keys[number]>, V<Keys[number]>> {
   return new Effect("Rc", (process) => {
-    const rcContext = process.context(RcContext);
-    const sig = U.id.of(target);
-    rcContext.increment(sig);
-    return () => {
-      return () => {
-        return rcContext.decrement(sig);
-      };
-    };
-  }, [target, ...keys]);
-}
-
-class RcContext extends Map<unknown, number> {
-  increment = (target: unknown) => {
-    const current = this.get(target);
-    if (current) {
-      this.set(target, current + 1);
-    } else {
-      this.set(target, 1);
+    const rcContext = process.context(Counters);
+    const sig = U.id.of(keys[0]);
+    let counter = rcContext.get(sig);
+    if (!counter) {
+      counter = new Counter();
+      rcContext.set(sig, counter);
     }
-  };
-
-  decrement = (target: unknown) => {
-    const current = this.get(target)!;
-    this.set(target, current - 1);
-    return current;
-  };
+    counter.i += 1;
+    return () => {
+      return [keys.map(process.resolve), counter!];
+    };
+  }, keys);
 }
+
+// @dprint-ignore-next-line
+export class Counter { i = 1 }
+export class Counters extends Map<string, Counter> {}

--- a/examples/client.ts
+++ b/examples/client.ts
@@ -4,7 +4,7 @@ import * as U from "../util/mod.ts";
 class ClientConnectError extends Error {
   override readonly name = "ClientConnectError";
 }
-class ClientDisconnectError extends Error {
+class _ClientDisconnectError extends Error {
   override readonly name = "ClientDisconnectError";
 }
 
@@ -12,7 +12,7 @@ class ClientDisconnectError extends Error {
 class InnerClient {
   constructor(readonly discoveryValue: string) {}
 
-  close = (): Promise<void | ClientDisconnectError> => {
+  close = (): Promise<void | _ClientDisconnectError> => {
     return new Promise<void>((resolve) => {
       setTimeout(resolve, 1000);
     });
@@ -49,13 +49,13 @@ function call<
   method: Method,
   args: Args,
 ) {
-  const deps = Z.ls(client, method, Z.ls(...args));
   return Z.call(
-    Z.ls(deps, Z.rc(client, deps)),
-    async ([[client, method, args], count]) => {
+    Z.rc(client, method, ...args),
+    async ([[client, method, ...args], counter]) => {
       console.log("ENTER CALL");
       const result = await client.send(method, args);
-      if (count() == 1) {
+      if (counter.i === 1) {
+        counter.i--;
         console.log("CLOSE CLIENT");
         const maybeCloseError = await client.close();
         if (maybeCloseError instanceof Error) return maybeCloseError;

--- a/examples/deduped.ts
+++ b/examples/deduped.ts
@@ -1,12 +1,22 @@
 import * as Z from "../mod.ts";
 
-let i = 0;
-
-function f() {
+let dupI = 0;
+function dup() {
   return Z.call(0, () => {
-    console.log(i++);
-    return "HELLO!";
+    return `${dupI++}`;
   });
 }
 
-await Z.runtime()(Z.ls(f(), f()));
+let dedupedI = 0;
+function deduped() {
+  return Z.call(0, function dedupedImpl() {
+    return `${dedupedI++}`;
+  });
+}
+
+const run = Z.runtime();
+
+const dupResult = run(Z.ls(dup(), dup())); // `["0", "1"]`
+const dedupedResult = run(Z.ls(deduped(), deduped())); // `["0", "0"]`
+
+console.log({ dupResult, dedupedResult });

--- a/words.txt
+++ b/words.txt
@@ -12,3 +12,4 @@ resolveds
 tjjfvi
 polkadot
 xsync
+deduped


### PR DESCRIPTION
This PR includes two changes:

1. The result of `rc` now contains its target and keys (as if a `ls`). This helps us avoid intermediate bloat.

**Prev**:

```ts
const deps = Z.ls(client, method, Z.ls(...args));
return Z.call(
  Z.ls(deps, Z.rc(client, deps)),
  async ([[client, method, args], count]) => {
```

**Now**:

```ts
return Z.call(
  Z.rc(client, method, ...args),
  async ([[client, method, ...args], counter]) => {
```

2. Cleaned up the `deduped` example