### PR TITLE
chore: ditch the ctor

### DIFF
--- a/Effect.ts
+++ b/Effect.ts
@@ -3,11 +3,11 @@ import { Process } from "./Process.ts";
 import * as U from "./util/mod.ts";
 
 export interface EffectProps {
-  /** A human-readable name for this type of Effect */
+  /** A human-readable name for this type of effect */
   readonly kind: string;
-  /** Any arguments (such as child Effects) used in the construction this effect */
+  /** Any arguments (such as child effects) used in the construction this effect */
   readonly args?: unknown[];
-  /** The Effect-specific runtime behavior */
+  /** The effect-specific runtime behavior */
   readonly run: EffectInitRun;
 }
 
@@ -36,7 +36,7 @@ export function effect<T, E extends Error, V extends PropertyKey>(
     as<U extends T>() {
       return this as unknown as Effect<U, E, V>;
     },
-    excludeError<S extends E>() {
+    excludeErr<S extends E>() {
       return this as unknown as Effect<T, Exclude<E, S>, V>;
     },
   };
@@ -50,16 +50,16 @@ export interface Effect<
   E extends Error = Error,
   V extends PropertyKey = PropertyKey,
 > extends EffectProps {
-  /** A branded, empty object, whose presence indicates the type is an Effect */
+  /** A branded, empty object, whose presence indicates the type is an effect */
   readonly [effect_]: EffectChannels<T, E, V>;
   /** An id, which encapsulates any child/argument ids */
   readonly id: string;
-  /** Utility method to create a new Effect that runs the current Effect and indexes into its result */
+  /** Utility method to create a new effect that runs the current effect and indexes into its result */
   readonly access: EffectAccess<T, E, V>;
   /** Override `T` */
   readonly as: EffectAs<T, E, V>;
   /** Exclude members of `E` */
-  readonly excludeError: EffectExcludeError<T, E, V>;
+  readonly excludeErr: EffectExcludeErr<T, E, V>;
 }
 
 declare const T_: unique symbol;
@@ -70,7 +70,7 @@ export type EffectChannels<T, E extends Error, V extends PropertyKey> = {
   readonly [T_]: T;
   /** The error result type */
   readonly [E_]: E;
-  /** Dependencies required by the Effect tree */
+  /** Dependencies required by the effect tree */
   readonly [V_]: V;
 };
 
@@ -82,7 +82,7 @@ export type EffectAs<T, E extends Error, V extends PropertyKey> = <
   U extends T,
 >() => Effect<U, E, V>;
 
-export type EffectExcludeError<
+export type EffectExcludeErr<
   T,
   E extends Error,
   V extends PropertyKey,

--- a/Process.ts
+++ b/Process.ts
@@ -1,4 +1,4 @@
-import { Effect } from "./Effect.ts";
+import { Effect, isEffect } from "./Effect.ts";
 import { isPlaceholder } from "./Placeholder.ts";
 
 export class Process extends Map<string, () => unknown> {
@@ -17,7 +17,7 @@ export class Process extends Map<string, () => unknown> {
         run = currentSource.run(this);
         this.set(currentSource.id, run);
         currentSource.children?.forEach((arg) => {
-          if (arg instanceof Effect) {
+          if (isEffect(arg)) {
             stack.push(arg);
           }
         });
@@ -31,7 +31,7 @@ export class Process extends Map<string, () => unknown> {
   };
 
   resolve = (x: unknown) => {
-    return x instanceof Effect
+    return isEffect(x)
       ? this.run(x)!()
       : isPlaceholder(x)
       ? this.applies[x.key]

--- a/Process.ts
+++ b/Process.ts
@@ -16,7 +16,7 @@ export class Process extends Map<string, () => unknown> {
       if (!run) {
         run = currentSource.run(this);
         this.set(currentSource.id, run);
-        currentSource.children?.forEach((arg) => {
+        currentSource.args?.forEach((arg) => {
           if (isEffect(arg)) {
             stack.push(arg);
           }

--- a/effects/call.ts
+++ b/effects/call.ts
@@ -1,4 +1,4 @@
-import { E, Effect, T, V } from "../Effect.ts";
+import { E, Effect, effect, T, V } from "../Effect.ts";
 import { thrownAsUntypedError } from "../Error.ts";
 import * as U from "../util/mod.ts";
 import { ls, Ls$ } from "./ls.ts";
@@ -7,11 +7,15 @@ export function call<D, R>(
   dep: D,
   logic: CallLogic<D, R>,
 ): Effect<Exclude<Awaited<R>, Error>, E<D> | Extract<Awaited<R>, Error>, V<D>> {
-  const e = new Effect("Call", (process) => {
-    return U.memo((): unknown => {
-      return U.thenOk(process.resolve(dep), thrownAsUntypedError(e, logic));
-    });
-  }, [dep, logic]);
+  const e = effect({
+    kind: "Call",
+    run: (process) => {
+      return U.memo((): unknown => {
+        return U.thenOk(process.resolve(dep), thrownAsUntypedError(e, logic));
+      });
+    },
+    children: [dep, logic],
+  });
   return e as any;
 }
 export namespace call {

--- a/effects/call.ts
+++ b/effects/call.ts
@@ -14,7 +14,7 @@ export function call<D, R>(
         return U.thenOk(process.resolve(dep), thrownAsUntypedError(e, logic));
       });
     },
-    children: [dep, logic],
+    args: [dep, logic],
   });
   return e as any;
 }

--- a/effects/derive.ts
+++ b/effects/derive.ts
@@ -16,7 +16,7 @@ export function derive<From, IntoR extends Effect>(
         );
       };
     },
-    children: [from, into],
+    args: [from, into],
   });
   return e as any;
 }

--- a/effects/derive.ts
+++ b/effects/derive.ts
@@ -1,4 +1,4 @@
-import { E, Effect, T, V } from "../Effect.ts";
+import { E, Effect, effect, T, V } from "../Effect.ts";
 import { thrownAsUntypedError } from "../Error.ts";
 import * as U from "../util/mod.ts";
 
@@ -6,14 +6,18 @@ export function derive<From, IntoR extends Effect>(
   from: From,
   into: DeriveInto<From, IntoR>,
 ): Effect<T<IntoR>, E<From | IntoR>, V<From | IntoR>> {
-  const e = new Effect("Derive", (process) => {
-    return (): unknown => {
-      return U.thenOk(
-        U.then(process.resolve(from), thrownAsUntypedError(e, into)),
-        (e) => process.init(e)(),
-      );
-    };
-  }, [from, into]);
+  const e = effect({
+    kind: "Derive",
+    run: (process) => {
+      return (): unknown => {
+        return U.thenOk(
+          U.then(process.resolve(from), thrownAsUntypedError(e, into)),
+          (e) => process.init(e)(),
+        );
+      };
+    },
+    children: [from, into],
+  });
   return e as any;
 }
 

--- a/effects/ls.ts
+++ b/effects/ls.ts
@@ -11,7 +11,7 @@ export function ls<Elements extends unknown[]>(
         return U.all(...elements.map(process.resolve));
       });
     },
-    children: elements,
+    args: elements,
   });
 }
 

--- a/effects/ls.ts
+++ b/effects/ls.ts
@@ -1,14 +1,18 @@
-import { $, E, Effect, T, V } from "../Effect.ts";
+import { $, E, Effect, effect, T, V } from "../Effect.ts";
 import * as U from "../util/mod.ts";
 
 export function ls<Elements extends unknown[]>(
   ...elements: Elements
 ): Effect<LsT<Elements>, E<Elements[number]>, V<Elements[number]>> {
-  return new Effect("Ls", (process) => {
-    return U.memo(() => {
-      return U.all(...elements.map(process.resolve));
-    });
-  }, elements);
+  return effect({
+    kind: "Ls",
+    run: (process) => {
+      return U.memo(() => {
+        return U.all(...elements.map(process.resolve));
+      });
+    },
+    children: elements,
+  });
 }
 
 export type Ls$<Elements> = {

--- a/effects/rc.ts
+++ b/effects/rc.ts
@@ -1,31 +1,36 @@
-import { E, Effect, V } from "../Effect.ts";
+import { E, Effect, effect, V } from "../Effect.ts";
 import * as U from "../util/mod.ts";
 import { LsT } from "./ls.ts";
 
-export type RcT<Keys extends [target: unknown, ...keys: unknown[]]> = [
+export type RcKeys = [target: unknown, ...keys: unknown[]];
+export type RcT<Keys extends RcKeys> = [
   LsT<Keys>,
   RcCounter,
 ];
 
-export function rc<Keys extends [target: unknown, ...keys: unknown[]]>(
+export function rc<Keys extends RcKeys>(
   ...keys: Keys
 ): Effect<RcT<Keys>, E<Keys[number]>, V<Keys[number]>> {
-  return new Effect("Rc", (process) => {
-    const rcContext = process.context(RcCounters);
-    const sig = U.id.of(keys[0]);
-    let counter = rcContext.get(sig);
-    if (!counter) {
-      counter = new RcCounter();
-      rcContext.set(sig, counter);
-    }
-    counter.i += 1;
-    return () => {
-      return U.thenOk(
-        U.all(...keys.map(process.resolve)),
-        (keys) => [keys, counter!],
-      );
-    };
-  }, keys);
+  return effect({
+    kind: "Rc",
+    run: (process) => {
+      const rcContext = process.context(RcCounters);
+      const sig = U.id.of(keys[0]);
+      let counter = rcContext.get(sig);
+      if (!counter) {
+        counter = new RcCounter();
+        rcContext.set(sig, counter);
+      }
+      counter.i += 1;
+      return () => {
+        return U.thenOk(
+          U.all(...keys.map(process.resolve)),
+          (keys) => [keys, counter!],
+        );
+      };
+    },
+    children: keys,
+  });
 }
 
 // @dprint-ignore-next-line

--- a/effects/rc.ts
+++ b/effects/rc.ts
@@ -29,7 +29,7 @@ export function rc<Keys extends RcKeys>(
         );
       };
     },
-    children: keys,
+    args: keys,
   });
 }
 

--- a/effects/rec.ts
+++ b/effects/rec.ts
@@ -1,27 +1,32 @@
-import { $, E, Effect, T, V } from "../Effect.ts";
+import { $, E, Effect, effect, T, V } from "../Effect.ts";
 import * as U from "../util/mod.ts";
 
 export function rec<Fields extends Record<PropertyKey, unknown>>(
   fields: Fields,
-  // TODO: should the V be U2Ied?
 ): Effect<RecT<Fields>, E<Fields[keyof Fields]>, V<Fields[keyof Fields]>> {
   const keys = Object.keys(fields);
   const values = Object.values(fields);
-  return new Effect("Rec", (process) => {
-    return U.memo(() => {
-      return U.thenOk(
-        U.all(...Object.values(fields).map(process.resolve)),
-        (values) => {
-          return keys.reduce((acc, cur, i) => {
-            return {
-              ...acc,
-              [cur]: values[i]!,
-            };
-          }, {});
-        },
-      );
-    });
-  }, [keys, values]);
+  return effect(
+    {
+      kind: "Rec",
+      run: (process) => {
+        return U.memo(() => {
+          return U.thenOk(
+            U.all(...Object.values(fields).map(process.resolve)),
+            (values) => {
+              return keys.reduce((acc, cur, i) => {
+                return {
+                  ...acc,
+                  [cur]: values[i]!,
+                };
+              }, {});
+            },
+          );
+        });
+      },
+      children: [keys, values],
+    },
+  );
 }
 
 export type Rec$<Fields> = { [K in keyof Fields]: $<Fields[K]> };

--- a/effects/rec.ts
+++ b/effects/rec.ts
@@ -24,7 +24,7 @@ export function rec<Fields extends Record<PropertyKey, unknown>>(
           );
         });
       },
-      children: [keys, values],
+      args: [keys, values],
     },
   );
 }

--- a/effects/try.ts
+++ b/effects/try.ts
@@ -20,7 +20,7 @@ export function try_<
         return U.thenErr(process.get(attempt.id)!(), fallback);
       });
     },
-    children: [attempt, fallback],
+    args: [attempt, fallback],
   });
 }
 Object.defineProperty(try_, "name", {

--- a/effects/try.ts
+++ b/effects/try.ts
@@ -1,4 +1,4 @@
-import { E, Effect, T, V } from "../Effect.ts";
+import { E, Effect, effect, T, V } from "../Effect.ts";
 import * as U from "../util/mod.ts";
 
 // TODO: fix this
@@ -13,11 +13,15 @@ export function try_<
   Extract<Awaited<FallbackR>, Error>,
   V<Attempt>
 > {
-  return new Effect("Try", (process) => {
-    return U.memo(() => {
-      return U.thenErr(process.get(attempt.id)!(), fallback);
-    });
-  }, [attempt, fallback]);
+  return effect({
+    kind: "Try",
+    run: (process) => {
+      return U.memo(() => {
+        return U.thenErr(process.get(attempt.id)!(), fallback);
+      });
+    },
+    children: [attempt, fallback],
+  });
 }
 Object.defineProperty(try_, "name", {
   value: "try",

--- a/effects/wrap.ts
+++ b/effects/wrap.ts
@@ -1,16 +1,20 @@
-import { $, E, Effect, T, V } from "../Effect.ts";
+import { $, E, Effect, effect, T, V } from "../Effect.ts";
 import * as U from "../util/mod.ts";
 
 export function wrap<Target extends $<object>, Key extends $<string>>(
   target: Target,
   key: Key,
 ): Effect<{ [_ in T<Key>]: T<Target> }, E<Target>, V<Target>> {
-  return new Effect("Wrap", (process) => {
-    return U.memo(() => {
-      return U.thenOk(
-        U.all(process.resolve(target), process.resolve(key)),
-        ([target, key]) => ({ [key]: target }),
-      );
-    });
-  }, [target, key]);
+  return effect({
+    kind: "Wrap",
+    run: (process) => {
+      return U.memo(() => {
+        return U.thenOk(
+          U.all(process.resolve(target), process.resolve(key)),
+          ([target, key]) => ({ [key]: target }),
+        );
+      });
+    },
+    children: [target, key],
+  });
 }

--- a/effects/wrap.ts
+++ b/effects/wrap.ts
@@ -15,6 +15,6 @@ export function wrap<Target extends $<object>, Key extends $<string>>(
         );
       });
     },
-    children: [target, key],
+    args: [target, key],
   });
 }

--- a/util/id.ts
+++ b/util/id.ts
@@ -1,4 +1,4 @@
-import { Effect } from "../Effect.ts";
+import { isEffect } from "../Effect.ts";
 import * as U from "../util/mod.ts";
 
 class IdFactory<T> {
@@ -32,7 +32,7 @@ export function of(target: unknown): string {
       return `fn(${target.name})`;
     }
     case "object": {
-      if (target instanceof Effect) {
+      if (isEffect(target)) {
         return target.id;
       } else if (target === null) {
         return "null";


### PR DESCRIPTION
We no longer instantiate an `Effect`, but rather use an `effect` factory, which accepts the props (same as before).