### PR TITLE
fix: ignore specific dnt errors

### DIFF
--- a/Error.ts
+++ b/Error.ts
@@ -10,6 +10,7 @@ export class ZonesError extends Error {
     "An untyped throw occurred within an effect-specific implementation";
   override readonly name = `ZonesError`;
   constructor(readonly source: Effect, thrown: unknown) {
+    // @ts-ignore dnt error TS2322: Type 'unknown' is not assignable to type 'Error | undefined'.
     super(ZonesError.MESSAGE, { cause: thrown });
   }
 }

--- a/effects/lift.ts
+++ b/effects/lift.ts
@@ -7,6 +7,7 @@ export function lift<V>(value: V): Effect<T<V>, E<V>> {
     kind: "Lift",
     impl: (env_) => {
       return () => {
+        // @ts-ignore dnt error TS2367: This condition will always return 'false' since the types 'V' and 'EnvFactory' have no overlap.
         return value === env ? env_ : value;
       };
     },

--- a/util/custom_inspect.ts
+++ b/util/custom_inspect.ts
@@ -31,7 +31,12 @@ export type Inspect = (value: unknown) => string;
 export type RuntimeAgnosticCustomInspect = (inspect: Inspect) => string;
 export type DenoCustomInspect = (
   this: CustomInspects,
-  inspect: (value: unknown, opts: Deno.InspectOptions) => string,
+  inspect: (
+    value: unknown,
+    // @ts-ignore dnt error TS2694: Namespace '"target/npm/node_modules/@deno/shim-deno-test/dist/test"' has no exported member 'InspectOptions'
+    opts: Deno.InspectOptions,
+  ) => string,
+  // @ts-ignore dnt error TS2694: Namespace '"target/npm/node_modules/@deno/shim-deno-test/dist/test"' has no exported member 'InspectOptions'
   opts: Deno.InspectOptions,
 ) => string;
 export type NodeCustomInspect = (


### PR DESCRIPTION
Dnt seem to be outdated for some Deno shims.
Also, Deno uses ES2022 and Dnt targets ES2021 (there is no ES2022) which seems to have a different type for the `ErrorOptions.cause`.

With these changes, `deno task dnt <version>` executes successfully
